### PR TITLE
adding phpmyadmin image

### DIFF
--- a/Build/docker-compose.yml
+++ b/Build/docker-compose.yml
@@ -34,6 +34,16 @@ services:
       interval: 5s
       timeout: 10s
       retries: 10
+  phpmyadmin:
+    image: phpmyadmin
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      - PMA_ARBITRARY=1
+    depends_on:
+      ntss_database:
+        condition: service_healthy
   app:
     container_name: ntss_app
     image: ntss_app


### PR DESCRIPTION
This allows everyone to have a UI to interact with the db

Do `docker compose -f Build/docker-compose.yml up -d --build --remove-orphans` to stand up phpmyadmin

To log into phpmyadmin use:
http://localhost:8080 in your browser or click the link in your docker containers list.

To login to the db on phpmyadmin
Server: ntss_database
User: get this from your .dbenvvars file use the MYSQL_USER value you set
Password: get this from your .dbenvvars file use the MYSQL_PASSWORD value you set

![image](https://github.com/josev814/csc470_ntss/assets/12461921/25c6efe2-63ed-421a-a7e5-0cd0e1963495)

Click on the ntss database

![image](https://github.com/josev814/csc470_ntss/assets/12461921/ee322ce9-4995-48f6-a685-0d65ec67773e)

Then you can browse, insert, search, drop, create tables.  This will be temporary, but since any modifications will be lost on a docker compose down.

It's helpful to test any SQL we're going to add to the setup.sql file